### PR TITLE
Use custom mesos-dns to fix NetworkInfo messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ MAINTAINER Spike Curtis <spike@projectcalico.org>
 ####################
 # Mesos-DNS
 ####################
-RUN curl -LO https://github.com/mesosphere/mesos-dns/releases/download/v0.4.0/mesos-dns-v0.4.0-linux-amd64.gz && \
-    gunzip mesos-dns-v0.4.0-linux-amd64.gz && \
-    mv mesos-dns-v0.4.0-linux-amd64 /usr/bin/mesos-dns && \
+RUN curl -LO https://github.com/Symmetric/mesos-dns/releases/download/v0.5.0alpha/mesos-dns && \
+    mv mesos-dns /usr/bin/mesos-dns && \
     chmod +x /usr/bin/mesos-dns
 
 ###################


### PR DESCRIPTION
Mesos 0.26.0 introduced a new message format for NetworkInfo.
Pull in a new Mesos-DNS which includes an update to support that
new message format.

Fixes the `make framework` tests (all failures apparently resolved
after applying this change).
